### PR TITLE
BREAKING CHANGE: new API to import this module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "/lib"
+    "./lib"
   ],
   "homepage": "https://github.com/mdapi-issues/listmetadata-recordtype-personaccount",
   "keywords": [
@@ -37,7 +37,7 @@
     "MWE"
   ],
   "license": "MIT",
-  "main": "/lib/workaround.js",
+  "main": "./lib/workaround.js",
   "publishConfig": {
     "access": "public"
   },

--- a/test/issue.e2e-spec.ts
+++ b/test/issue.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Org } from '@salesforce/core';
 import { expect } from 'chai';
-import listRecordTypes from './issue';
+import { listRecordTypes } from './issue';
 
 describe('listMetadata', function () {
   this.slow(5000);

--- a/test/issue.ts
+++ b/test/issue.ts
@@ -1,6 +1,6 @@
 import type { FileProperties, Connection } from 'jsforce';
 
-export default async function listRecordTypes(
+export async function listRecordTypes(
   conn: Connection
 ): Promise<Array<FileProperties>> {
   let fileProperties = await conn.metadata.list({ type: 'RecordType' });

--- a/test/workaround.e2e-spec.ts
+++ b/test/workaround.e2e-spec.ts
@@ -4,7 +4,7 @@ import {
   fixPersonAccountRecordTypes,
   queryPersonAccountRecordTypes
 } from '../src/workaround';
-import listRecordTypes from './issue';
+import { listRecordTypes } from './issue';
 
 describe('workaround', function () {
   this.slow(5000);


### PR DESCRIPTION
Make the workaround the primary entry point of this module.

Please migrate your code as follows:

```diff
 import {
  fixPersonAccountRecordTypes,
  queryPersonAccountRecordTypes
-} from '@mdapi-issues/listmetadata-recordtypes-personaccount/lib/workaround';
 import {
  fixPersonAccountRecordTypes,
  queryPersonAccountRecordTypes
+} from '@mdapi-issues/listmetadata-recordtypes-personaccount';
```